### PR TITLE
fix: Ensure leaf image is removed only if it has a parent node

### DIFF
--- a/package/themes/autumn/index.js
+++ b/package/themes/autumn/index.js
@@ -111,7 +111,7 @@ export default {
       requestAnimationFrame(frame);
 
       const removeTimer = setTimeout(() => {
-        img.remove();
+        if (img.parentNode) img.remove();
         timeouts.delete(removeTimer);
       }, (duration + delay) * 1000 + 200);
       timeouts.add(removeTimer);


### PR DESCRIPTION
Resolved the assignee's issue: added a null check before removing the leaf element to prevent errors if it was already removed. Change is in package/themes/autumn/index.js.

This pull request makes a minor improvement to the `autumn` theme's JavaScript. It updates the image removal logic to ensure that `img.remove()` is only called if the image is still attached to the DOM, preventing potential errors.

```
// ...existing code...
      const removeTimer = setTimeout(() => {
        // Resolved: Added null check before removing img to prevent errors if already removed
        if (img.parentNode) img.remove();
        timeouts.delete(removeTimer);
      }, (duration + delay) * 1000 + 200);
      timeouts.add(removeTimer);
// ...existing code...
```


This pull request includes a minor update to the `autumn` theme's animation cleanup logic. The change ensures that the code safely removes an image element only if it is still attached to the DOM, preventing potential errors.