### PR TITLE
feat: Add Rain section with interactive buttons to the example page

### DIFF
--- a/package/examples/index.html
+++ b/package/examples/index.html
@@ -93,6 +93,14 @@
       <button onclick="Festive.init({forceTheme:'autumn', themes: {'autumn': {count: 120}}})">Denser Leaves</button>
     </div>
 
+    <!-- Rain Section -->
+    <h2 style="font-size: 1.5rem; margin: 2rem 0 1rem 0; color: #87ceeb;">Rain</h2>
+    <div class="buttons">
+      <button onclick="Festive.init({forceTheme:'rain'})">Gentle Rain</button>
+      <button onclick="Festive.init({forceTheme:'rain', themes: {'rain': {thunder: true}}})">Thunderstorm</button>
+      <button onclick="Festive.init({forceTheme:'rain', themes: {'rain': {dropInterval: 40, dropColor: 'rgba(174,194,224,0.8)'}}})">Heavy Rain</button>
+    </div>
+
     <div class="clear-section">
       <button class="clear-btn" onclick="Festive.destroy?.()">Clear</button>
     </div>

--- a/package/themes/autumn/index.js
+++ b/package/themes/autumn/index.js
@@ -111,7 +111,7 @@ export default {
       requestAnimationFrame(frame);
 
       const removeTimer = setTimeout(() => {
-        if (img.parentNode) img.remove();
+        img.remove();
         timeouts.delete(removeTimer);
       }, (duration + delay) * 1000 + 200);
       timeouts.add(removeTimer);


### PR DESCRIPTION
This pull request introduces a new rain-themed animation to the example page and makes a minor code simplification in the autumn theme implementation. The most significant change is the addition of a "Rain" section with interactive buttons for different rain effects, enhancing the demo's variety and user experience.

**New Feature: Rain Animation**
* Added a "Rain" section to `package/examples/index.html` with buttons for "Gentle Rain," "Thunderstorm," and "Heavy Rain," allowing users to preview multiple rain effects.

**Code Simplification**
* Simplified the leaf removal logic in `package/themes/autumn/index.js` by directly calling `img.remove()` instead of checking for the parent node.