### PR TITLE
fix: Refactor firework image creation for improved clarity and mainta…

### DIFF
--- a/package/themes/diwali/index.js
+++ b/package/themes/diwali/index.js
@@ -85,9 +85,6 @@ export default {
     }
 
     function createFirework() {
-      const firework = document.createElement("img");
-      firework.className = "diwali-firework";
-      
       // Safe fallback for images with guard against empty arrays
       const images = (cfg.fireworkImages && cfg.fireworkImages.length) 
         ? cfg.fireworkImages 
@@ -95,6 +92,8 @@ export default {
       
       if (!images || !images.length) return; // No images to show, skip
       
+      const firework = document.createElement("img");
+      firework.className = "diwali-firework";
       firework.src = images[Math.floor(Math.random() * images.length)];
       const size = Math.random() * (cfg.maxSize - cfg.minSize) + cfg.minSize;
 


### PR DESCRIPTION
This pull request makes a minor adjustment to the `createFirework` function in `package/themes/diwali/index.js`. The change moves the creation of the `firework` image element to after the image array validation, ensuring that no unnecessary DOM elements are created when there are no images to display. Resolves issue raised in pull request #12 
