### PR TITLE
feat(lunar-new-year): Enhance theme animation and robustness

### DIFF
--- a/package/themes/lunar-new-year/index.js
+++ b/package/themes/lunar-new-year/index.js
@@ -28,18 +28,21 @@ export default {
     let alive = true;
     const timers = new Set();
 
-    // Inject CSS keyframes once
-    const style = document.createElement('style');
-    style.textContent = `
-      @keyframes lantern-sway {
-        0% { transform: translateX(0); }
-        25% { transform: translateX(${cfg.swayAmplitude}px); }
-        50% { transform: translateX(0); }
-        75% { transform: translateX(-${cfg.swayAmplitude}px); }
-        100% { transform: translateX(0); }
-      }
-    `;
-    document.head.appendChild(style);
+    const styleId = 'lunar-new-year-lantern-sway-style';
+    if (!document.getElementById(styleId)) {
+      const style = document.createElement('style');
+      style.id = styleId;
+      style.textContent = `
+        @keyframes lantern-sway {
+          0% { transform: translateX(0); }
+          25% { transform: translateX(${cfg.swayAmplitude}px); }
+          50% { transform: translateX(0); }
+          75% { transform: translateX(-${cfg.swayAmplitude}px); }
+          100% { transform: translateX(0); }
+        }
+      `;
+      document.head.appendChild(style);
+    }
 
     const container = document.createElement('div');
     Object.assign(container.style, {
@@ -93,11 +96,19 @@ export default {
           holder.style.opacity = '0';
         });
 
-        const removeOnEnd = () => {
+        let cleanedUp = false;
+        const cleanup = () => {
+          if (cleanedUp) return;
+          cleanedUp = true;
           holder.removeEventListener('transitionend', removeOnEnd);
+          clearTimeout(fallbackTimeout);
           if (holder.parentNode) holder.remove();
         };
+        const removeOnEnd = () => {
+          cleanup();
+        };
         holder.addEventListener('transitionend', removeOnEnd);
+        const fallbackTimeout = setTimeout(cleanup, cfg.floatDuration + 100);
       }
     }
 
@@ -110,7 +121,8 @@ export default {
       timers.forEach(clearInterval);
       timers.clear();
       if (container.parentNode) container.remove();
-      if (style.parentNode) style.remove();
+      const style = document.getElementById(styleId);
+      if (style && style.parentNode) style.remove();
     };
   },
 };


### PR DESCRIPTION
This pull request refines the implementation of the Lunar New Year theme by improving how the lantern sway animation CSS is injected and cleaned up, and by making the lantern removal process more robust. The changes enhance resource management and prevent potential issues with duplicate style elements and lingering DOM nodes.

**Theme: CSS Injection and Cleanup**

* Ensured that the lantern sway animation CSS is injected only once by assigning a unique `styleId` and checking for its existence before adding the style element. [[1]](diffhunk://#diff-e1037cb08bed0db6714a19fa437909f1220dfccd00a20d816ea17636d48b9104L31-R34) [[2]](diffhunk://#diff-e1037cb08bed0db6714a19fa437909f1220dfccd00a20d816ea17636d48b9104R45)
* Updated the cleanup logic to remove the style element by its unique ID, ensuring that only the correct style is removed during theme teardown.

**Theme: Lantern Removal Robustness**

* Improved the lantern removal process by introducing a `cleanup` function that prevents multiple removals, clears the fallback timeout, and ensures the DOM node is removed safely. This function is triggered on both transition end and a fallback timeout to handle edge cases.