### PR TITLE
feat(theme): Added Independence Day theme with modularity and triggers

### DIFF
--- a/package/examples/index.html
+++ b/package/examples/index.html
@@ -71,11 +71,15 @@
     <!-- Independence Day Section -->
     <h2 style="font-size: 1.5rem; margin: 2rem 0 1rem 0; color: #FF9933;">Independence Day</h2>
     <div class="buttons">
+      <!-- Manual-init example that specifies which flag to use for the independence-day theme.
+          You can add more buttons by copying this and changing the flag name. -->
       <button onclick="Festive.init({forceTheme:'independence-day', themes: {'independence-day': {flag: 'Indian Flag'}}})">Waving Indian Flag</button>
-      <!-- To add a new flag button, copy the button above and change the 'flag' property to the name of the new flag. -->
-      <!-- e.g., <button onclick="Festive.init({forceTheme:'independence-day', themes: {'independence-day': {flag: 'USA Flag'}}})">Waving USA Flag</button> -->
+      <!-- Example for adding another flag:
+          <button onclick="Festive.init({forceTheme:'independence-day', themes: {'independence-day': {flag: 'USA Flag'}}})">Waving USA Flag</button>
+      -->
     </div>
 
+<!-- Valentine's Day Section -->
     <!-- Valentine's Day Section -->
     <h2 style="font-size: 1.5rem; margin: 2rem 0 1rem 0; color: #ff4081;">Valentine's Day</h2>
     <div class="buttons">

--- a/package/examples/index.html
+++ b/package/examples/index.html
@@ -69,9 +69,11 @@
     <h1>Festive Themes</h1>
 
     <!-- Independence Day Section -->
-    <h2 style="font-size: 1.5rem; margin: 2rem 0 1rem 0; color: #FF9933;">Independence Day - Indian Flag</h2>
+    <h2 style="font-size: 1.5rem; margin: 2rem 0 1rem 0; color: #FF9933;">Independence Day</h2>
     <div class="buttons">
-      <button onclick="Festive.init({forceTheme:'independence-day'})">Indian Flag</button>
+      <button onclick="Festive.init({forceTheme:'independence-day', themes: {'independence-day': {flag: 'Indian Flag'}}})">Waving Indian Flag</button>
+      <!-- To add a new flag button, copy the button above and change the 'flag' property to the name of the new flag. -->
+      <!-- e.g., <button onclick="Festive.init({forceTheme:'independence-day', themes: {'independence-day': {flag: 'USA Flag'}}})">Waving USA Flag</button> -->
     </div>
 
     <!-- Valentine's Day Section -->

--- a/package/themes/independence-day/index.js
+++ b/package/themes/independence-day/index.js
@@ -1,64 +1,73 @@
 /**
+ * Independence Day — modular flag-based theme
+ *
  * To add a new flag:
- * 1. Create a new file in this directory (e.g., `usa.js`).
- * 2. Define the flag's properties in the new file, following the structure of `india.js`.
- * 3. Import the new flag file below.
- * 4. Add the imported flag object to the `flags` array.
+ * 1. Create a new file in this directory (e.g., `usa.js`) that exports the flag object.
+ * 2. Import it below and add it to the `flags` array.
  */
 
 import india from './india.js';
 
-// To add a new flag, import its file and add it to this array.
-const flags = [india]; // e.g., import usa from './usa.js'; flags.push(usa);
+// Add other flags here when available:
+// import usa from './usa.js';
+const flags = [india]; // e.g., const flags = [india, usa];
 
-// Combine all triggers from all flags into one array for the theme.
-const allTriggers = flags.flatMap(flag => flag.triggers || []);
+const allTriggers = flags.flatMap(f => f.triggers || []);
 
 export default {
   key: 'independence-day',
   name: 'Independence Day',
   triggers: allTriggers,
   apply(root = document.body, common = {}, options = {}) {
+    // Determine requested flag: support options.flag or options.themes['independence-day'].flag
+    const manualFlagName =
+      options.flag ||
+      (options.themes && options.themes['independence-day'] && options.themes['independence-day'].flag);
+
     let flag;
 
-    // If manually triggered with a specific flag name, find that flag.
-    if (options.flag) {
-        flag = flags.find(f => f.name === options.flag);
+    if (manualFlagName) {
+      const wanted = String(manualFlagName).toLowerCase();
+      flag = flags.find(f => String(f.name || '').toLowerCase() === wanted);
     } else {
-        // If auto-triggered, find the flag whose trigger matches the current date.
-        const today = new Date();
-        const currentMonth = today.getMonth() + 1; // getMonth() is 0-indexed
-        const currentDay = today.getDate();
+      // Auto-select flag based on today's date and each flag's triggers
+      const today = new Date();
+      const currentMonth = today.getMonth() + 1; // 1-12
+      const currentDay = today.getDate();
 
-        flag = flags.find(f => {
-            if (!f.triggers) return false;
-            return f.triggers.some(trigger => {
-                if (trigger.type !== 'range') return false;
+      flag = flags.find(f => {
+        if (!f.triggers) return false;
+        return f.triggers.some(trigger => {
+          if (trigger.type !== 'range') return false;
 
-                // Handle date ranges that are within the same month.
-                if (trigger.monthStart === trigger.monthEnd) {
-                    return currentMonth === trigger.monthStart && currentDay >= trigger.dayStart && currentDay <= trigger.dayEnd;
-                }
+          // Same-month range
+          if (trigger.monthStart === trigger.monthEnd) {
+            return (
+              currentMonth === trigger.monthStart &&
+              currentDay >= trigger.dayStart &&
+              currentDay <= trigger.dayEnd
+            );
+          }
 
-                // Handle date ranges that span across multiple months (assumes within the same year).
-                const inStartMonth = currentMonth === trigger.monthStart && currentDay >= trigger.dayStart;
-                const inEndMonth = currentMonth === trigger.monthEnd && currentDay <= trigger.dayEnd;
-                const inBetweenMonth = currentMonth > trigger.monthStart && currentMonth < trigger.monthEnd;
-                
-                return inStartMonth || inEndMonth || inBetweenMonth;
-            });
+          // Range across months (assumes same year)
+          const inStartMonth = currentMonth === trigger.monthStart && currentDay >= trigger.dayStart;
+          const inEndMonth = currentMonth === trigger.monthEnd && currentDay <= trigger.dayEnd;
+          const inBetween = currentMonth > trigger.monthStart && currentMonth < trigger.monthEnd;
+
+          return inStartMonth || inEndMonth || inBetween;
         });
+      });
     }
 
-    // Default to the first flag in the array if no specific flag is found.
+    // Default to first flag if none matched
     flag = flag || flags[0];
 
     const cfg = {
-      palette: flag.palette,
+      palette: flag.palette || options.palette || ['#FF9933', '#FFFFFF', '#138808'],
       speed: options.speed || 0.4,
-      amplitude: options.amplitude || 0.08,
-      alpha: options.alpha ?? 0.15, // Reduced opacity for better visibility
-      blend: options.blend || 'multiply' // Changed blend mode for better background effect
+      amplitude: options.amplitude || 0.08, // relative to height
+      alpha: options.alpha ?? 0.15,
+      blend: options.blend || 'multiply'
     };
 
     const overlay = document.createElement('div');
@@ -67,7 +76,7 @@ export default {
       position: 'fixed',
       inset: '0',
       pointerEvents: 'none',
-      zIndex: '-1', // Keeps it behind all content
+      zIndex: '-1', // keep behind content
       mixBlendMode: cfg.blend,
       opacity: String(cfg.alpha),
       overflow: 'hidden'
@@ -85,14 +94,26 @@ export default {
 
     function resize() {
       dpr = Math.max(1, window.devicePixelRatio || 1);
-      canvas.width = Math.floor(canvas.clientWidth * dpr);
-      canvas.height = Math.floor(canvas.clientHeight * dpr);
+      const w = Math.max(1, canvas.clientWidth || canvas.offsetWidth);
+      const h = Math.max(1, canvas.clientHeight || canvas.offsetHeight);
+      canvas.width = Math.floor(w * dpr);
+      canvas.height = Math.floor(h * dpr);
       ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
     }
+    // Initial sizing
     resize();
 
     let rafId = null;
     let start = performance.now();
+
+    function getWaveY(x, t, w, h, cfgLocal) {
+      const xFactor = x / (w * 0.5);
+      const waveAmplitude = h * cfgLocal.amplitude;
+      return (
+        Math.sin(xFactor * Math.PI + t) * waveAmplitude * Math.cos(t / 3) +
+        Math.cos(xFactor * Math.PI * 0.7 + t * 1.2) * waveAmplitude * 0.5
+      );
+    }
 
     function draw(now) {
       const t = (now - start) / 4000 * cfg.speed;
@@ -101,34 +122,32 @@ export default {
       ctx.clearRect(0, 0, w, h);
 
       const stripeHeight = h / cfg.palette.length;
-      const waveAmplitude = h * cfg.amplitude;
-
-      const getWaveY = (x, t) => {
-        const xFactor = x / (w * 0.5);
-        return Math.sin(xFactor * Math.PI + t) * waveAmplitude * Math.cos(t / 3) +
-               Math.cos(xFactor * Math.PI * 0.7 + t * 1.2) * waveAmplitude * 0.5;
-      };
 
       for (let i = 0; i < cfg.palette.length; i++) {
         ctx.fillStyle = cfg.palette[i];
         ctx.beginPath();
         const y0 = i * stripeHeight;
-        ctx.moveTo(0, y0 + getWaveY(0, t));
+        ctx.moveTo(0, y0 + getWaveY(0, t, w, h, cfg));
         for (let x = 1; x <= w; x += 5) {
-          ctx.lineTo(x, y0 + getWaveY(x, t));
+          ctx.lineTo(x, y0 + getWaveY(x, t, w, h, cfg));
         }
         const y1 = (i + 1) * stripeHeight;
-        ctx.lineTo(w, y1 + getWaveY(w, t));
+        ctx.lineTo(w, y1 + getWaveY(w, t, w, h, cfg));
         for (let x = w; x >= 0; x -= 5) {
-          ctx.lineTo(x, y1 + getWaveY(x, t));
+          ctx.lineTo(x, y1 + getWaveY(x, t, w, h, cfg));
         }
         ctx.closePath();
         ctx.fill();
       }
 
-      // If the flag has a custom element (like the Ashoka Chakra), draw it.
+      // Draw custom element (e.g., Ashoka Chakra) if provided by the flag
       if (flag.drawCustomElement) {
-        flag.drawCustomElement(ctx, w, h, stripeHeight, getWaveY, t);
+        try {
+          flag.drawCustomElement(ctx, w, h, stripeHeight, (x, tn) => getWaveY(x, tn, w, h, cfg), t);
+        } catch (err) {
+          // Fail silently to avoid breaking the animation loop
+          console.error('Error drawing custom element for independence-day flag:', err);
+        }
       }
 
       rafId = requestAnimationFrame(draw);

--- a/package/themes/independence-day/index.js
+++ b/package/themes/independence-day/index.js
@@ -1,41 +1,76 @@
+/**
+ * To add a new flag:
+ * 1. Create a new file in this directory (e.g., `usa.js`).
+ * 2. Define the flag's properties in the new file, following the structure of `india.js`.
+ * 3. Import the new flag file below.
+ * 4. Add the imported flag object to the `flags` array.
+ */
+
+import india from './india.js';
+
+// To add a new flag, import its file and add it to this array.
+const flags = [india]; // e.g., import usa from './usa.js'; flags.push(usa);
+
+// Combine all triggers from all flags into one array for the theme.
+const allTriggers = flags.flatMap(flag => flag.triggers || []);
+
 export default {
   key: 'independence-day',
-  name: 'Independence Day - Indian Flag',
-  triggers: [
-    {
-      type: 'range',
-      monthStart: 8,
-      dayStart: 1,
-      monthEnd: 8,
-      dayEnd: 31,
-    },
-  ],
+  name: 'Independence Day',
+  triggers: allTriggers,
   apply(root = document.body, common = {}, options = {}) {
+    let flag;
+
+    // If manually triggered with a specific flag name, find that flag.
+    if (options.flag) {
+        flag = flags.find(f => f.name === options.flag);
+    } else {
+        // If auto-triggered, find the flag whose trigger matches the current date.
+        const today = new Date();
+        const currentMonth = today.getMonth() + 1; // getMonth() is 0-indexed
+        const currentDay = today.getDate();
+
+        flag = flags.find(f => {
+            if (!f.triggers) return false;
+            return f.triggers.some(trigger => {
+                if (trigger.type !== 'range') return false;
+
+                // Handle date ranges that are within the same month.
+                if (trigger.monthStart === trigger.monthEnd) {
+                    return currentMonth === trigger.monthStart && currentDay >= trigger.dayStart && currentDay <= trigger.dayEnd;
+                }
+
+                // Handle date ranges that span across multiple months (assumes within the same year).
+                const inStartMonth = currentMonth === trigger.monthStart && currentDay >= trigger.dayStart;
+                const inEndMonth = currentMonth === trigger.monthEnd && currentDay <= trigger.dayEnd;
+                const inBetweenMonth = currentMonth > trigger.monthStart && currentMonth < trigger.monthEnd;
+                
+                return inStartMonth || inEndMonth || inBetweenMonth;
+            });
+        });
+    }
+
+    // Default to the first flag in the array if no specific flag is found.
+    flag = flag || flags[0];
+
     const cfg = {
-      palette: options.palette || [
-        '#FF9933', // Saffron
-        '#FFFFFF', // White
-        '#138808'  // Green
-      ],
-      speed: options.speed || 0.5,
-      waveFrequency: options.waveFrequency || 3,
-      waveAmplitude: options.waveAmplitude || 20,
-      alpha: options.alpha ?? 0.25,
-      blend: options.blend || 'normal'
+      palette: flag.palette,
+      speed: options.speed || 0.4,
+      amplitude: options.amplitude || 0.08,
+      alpha: options.alpha ?? 0.15, // Reduced opacity for better visibility
+      blend: options.blend || 'multiply' // Changed blend mode for better background effect
     };
 
     const overlay = document.createElement('div');
     overlay.className = 'festive-independence-day-overlay';
     Object.assign(overlay.style, {
       position: 'fixed',
-      top: '0',
-      left: '0',
-      width: '100%',
-      height: '100%',
+      inset: '0',
       pointerEvents: 'none',
-      zIndex: '0',
+      zIndex: '-1', // Keeps it behind all content
       mixBlendMode: cfg.blend,
-      opacity: String(cfg.alpha)
+      opacity: String(cfg.alpha),
+      overflow: 'hidden'
     });
 
     const canvas = document.createElement('canvas');
@@ -45,11 +80,11 @@ export default {
     overlay.appendChild(canvas);
     root.appendChild(overlay);
 
-    const ctx = canvas.getContext('2d', { alpha: true });
-    let dpr = Math.max(1, Math.min(window.devicePixelRatio || 1, 2));
+    const ctx = canvas.getContext('2d');
+    let dpr = Math.max(1, window.devicePixelRatio || 1);
 
     function resize() {
-      dpr = Math.max(1, Math.min(window.devicePixelRatio || 1, 2));
+      dpr = Math.max(1, window.devicePixelRatio || 1);
       canvas.width = Math.floor(canvas.clientWidth * dpr);
       canvas.height = Math.floor(canvas.clientHeight * dpr);
       ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
@@ -57,140 +92,54 @@ export default {
     resize();
 
     let rafId = null;
-    const start = performance.now();
+    let start = performance.now();
 
     function draw(now) {
-      const t = (now - start) / 1000 * cfg.speed;
+      const t = (now - start) / 4000 * cfg.speed;
       const w = canvas.clientWidth;
       const h = canvas.clientHeight;
-      
       ctx.clearRect(0, 0, w, h);
 
-      const stripeHeight = h / 3;
-      const step = 3; // Points for smooth curves
+      const stripeHeight = h / cfg.palette.length;
+      const waveAmplitude = h * cfg.amplitude;
 
-      // Wave function - creates horizontal waves
-      const getWaveOffset = (x, t) => {
-        return Math.sin((x / w) * Math.PI * cfg.waveFrequency - t * 2) * cfg.waveAmplitude;
+      const getWaveY = (x, t) => {
+        const xFactor = x / (w * 0.5);
+        return Math.sin(xFactor * Math.PI + t) * waveAmplitude * Math.cos(t / 3) +
+               Math.cos(xFactor * Math.PI * 0.7 + t * 1.2) * waveAmplitude * 0.5;
       };
 
-      // Get brightness for 3D effect
-      const getBrightness = (x, t) => {
-        const waveDerivative = Math.cos((x / w) * Math.PI * cfg.waveFrequency - t * 2);
-        return 1 + (waveDerivative * 0.25); // Subtle shading
-      };
-
-      // Draw each stripe with connected waves
-      for (let stripeIdx = 0; stripeIdx < 3; stripeIdx++) {
-        const baseY = stripeIdx * stripeHeight;
-        
+      for (let i = 0; i < cfg.palette.length; i++) {
+        ctx.fillStyle = cfg.palette[i];
         ctx.beginPath();
-        
-        // Top edge of stripe
-        ctx.moveTo(0, baseY + getWaveOffset(0, t));
-        for (let x = step; x <= w; x += step) {
-          const y = baseY + getWaveOffset(x, t);
-          ctx.lineTo(x, y);
+        const y0 = i * stripeHeight;
+        ctx.moveTo(0, y0 + getWaveY(0, t));
+        for (let x = 1; x <= w; x += 5) {
+          ctx.lineTo(x, y0 + getWaveY(x, t));
         }
-        
-        // Bottom edge of stripe (reversed direction)
-        const nextBaseY = (stripeIdx + 1) * stripeHeight;
-        ctx.lineTo(w, nextBaseY + getWaveOffset(w, t));
-        for (let x = w - step; x >= 0; x -= step) {
-          const y = nextBaseY + getWaveOffset(x, t);
-          ctx.lineTo(x, y);
+        const y1 = (i + 1) * stripeHeight;
+        ctx.lineTo(w, y1 + getWaveY(w, t));
+        for (let x = w; x >= 0; x -= 5) {
+          ctx.lineTo(x, y1 + getWaveY(x, t));
         }
-        
         ctx.closePath();
-
-        // Create gradient for 3D shading effect
-        const gradient = ctx.createLinearGradient(0, 0, w, 0);
-        const baseColor = cfg.palette[stripeIdx];
-        
-        // Parse base color and apply shading across the width
-        let r, g, b;
-        if (stripeIdx === 0) { // Saffron
-          r = 255; g = 153; b = 51;
-        } else if (stripeIdx === 1) { // White
-          r = 255; g = 255; b = 255;
-        } else { // Green
-          r = 19; g = 136; b = 8;
-        }
-
-        // Add gradient stops with brightness variations
-        const stops = 20;
-        for (let i = 0; i <= stops; i++) {
-          const x = (i / stops) * w;
-          const brightness = getBrightness(x, t);
-          const shadedR = Math.floor(Math.min(255, r * brightness));
-          const shadedG = Math.floor(Math.min(255, g * brightness));
-          const shadedB = Math.floor(Math.min(255, b * brightness));
-          gradient.addColorStop(i / stops, `rgb(${shadedR}, ${shadedG}, ${shadedB})`);
-        }
-
-        ctx.fillStyle = gradient;
         ctx.fill();
       }
 
-      // Draw Ashoka Chakra in the center
-      const chakraY = h / 2;
-      const chakraX = w / 2;
-      const chakraRadius = Math.min(stripeHeight / 3.5, 35);
-      
-      // Position chakra with the wave
-      const chakraOffset = getWaveOffset(chakraX, t);
-      const finalChakraY = chakraY + chakraOffset;
-      const chakraBrightness = getBrightness(chakraX, t);
-
-      ctx.save();
-      
-      // Apply shading to chakra color
-      const navyR = Math.floor(0 * chakraBrightness);
-      const navyG = Math.floor(0 * chakraBrightness);
-      const navyB = Math.floor(128 * chakraBrightness);
-      ctx.strokeStyle = `rgb(${navyR}, ${navyG}, ${navyB})`;
-      
-      // Outer circle
-      ctx.lineWidth = Math.max(2, chakraRadius / 12);
-      ctx.beginPath();
-      ctx.arc(chakraX, finalChakraY, chakraRadius, 0, 2 * Math.PI);
-      ctx.stroke();
-
-      // Inner hub
-      ctx.lineWidth = Math.max(1.5, chakraRadius / 15);
-      ctx.beginPath();
-      ctx.arc(chakraX, finalChakraY, chakraRadius * 0.15, 0, 2 * Math.PI);
-      ctx.stroke();
-
-      // 24 spokes
-      ctx.lineWidth = Math.max(1.2, chakraRadius / 18);
-      for (let i = 0; i < 24; i++) {
-        const angle = (i / 24) * 2 * Math.PI;
-        const innerRadius = chakraRadius * 0.15;
-        const startX = chakraX + innerRadius * Math.cos(angle);
-        const startY = finalChakraY + innerRadius * Math.sin(angle);
-        const endX = chakraX + chakraRadius * Math.cos(angle);
-        const endY = finalChakraY + chakraRadius * Math.sin(angle);
-        
-        ctx.beginPath();
-        ctx.moveTo(startX, startY);
-        ctx.lineTo(endX, endY);
-        ctx.stroke();
+      // If the flag has a custom element (like the Ashoka Chakra), draw it.
+      if (flag.drawCustomElement) {
+        flag.drawCustomElement(ctx, w, h, stripeHeight, getWaveY, t);
       }
-      
-      ctx.restore();
 
       rafId = requestAnimationFrame(draw);
     }
 
     rafId = requestAnimationFrame(draw);
-    
-    const resizeObserver = new ResizeObserver(resize);
-    resizeObserver.observe(canvas);
+    window.addEventListener('resize', resize);
 
     return () => {
       if (rafId) cancelAnimationFrame(rafId);
-      resizeObserver.disconnect();
+      window.removeEventListener('resize', resize);
       if (overlay.parentNode) overlay.parentNode.removeChild(overlay);
     };
   }

--- a/package/themes/independence-day/india.js
+++ b/package/themes/independence-day/india.js
@@ -1,0 +1,43 @@
+export default {
+  name: 'Indian Flag',
+  // The date range when this flag's theme should be auto-triggered.
+  triggers: [
+    {
+      type: 'range',
+      monthStart: 8,
+      dayStart: 15,
+      monthEnd: 8,
+      dayEnd: 15,
+    }
+  ],
+  palette: [
+    '#FF9933', // Saffron
+    '#FFFFFF', // White
+    '#138808'  // Green
+  ],
+  drawCustomElement: (ctx, w, h, stripeHeight, getWaveY, t) => {
+    const chakraRadius = Math.min(stripeHeight / 2.5, 30);
+    const chakraX = w / 2;
+    const yOffsetChakra = getWaveY(chakraX, t);
+    const chakraY = h / 2 + yOffsetChakra;
+
+    ctx.strokeStyle = '#000080';
+    ctx.lineWidth = Math.max(1.5, chakraRadius/12);
+    ctx.beginPath();
+    ctx.arc(chakraX, chakraY, chakraRadius, 0, 2 * Math.PI);
+    ctx.stroke();
+
+    ctx.lineWidth = Math.max(1, chakraRadius/20);
+    for (let i = 0; i < 24; i++) {
+      const angle = (i / 24) * 2 * Math.PI;
+      const startX = chakraX;
+      const startY = chakraY;
+      const endX = chakraX + chakraRadius * Math.cos(angle);
+      const endY = chakraY + chakraRadius * Math.sin(angle);
+      ctx.beginPath();
+      ctx.moveTo(startX, startY);
+      ctx.lineTo(endX, endY);
+      ctx.stroke();
+    }
+  }
+};

--- a/package/themes/independence-day/india.js
+++ b/package/themes/independence-day/india.js
@@ -1,13 +1,13 @@
 export default {
   name: 'Indian Flag',
-  // The date range when this flag's theme should be auto-triggered.
+  // Auto-trigger date range for this flag
   triggers: [
     {
       type: 'range',
       monthStart: 8,
       dayStart: 15,
       monthEnd: 8,
-      dayEnd: 15,
+      dayEnd: 15
     }
   ],
   palette: [
@@ -21,23 +21,27 @@ export default {
     const yOffsetChakra = getWaveY(chakraX, t);
     const chakraY = h / 2 + yOffsetChakra;
 
+    ctx.save();
     ctx.strokeStyle = '#000080';
-    ctx.lineWidth = Math.max(1.5, chakraRadius/12);
+    ctx.lineWidth = Math.max(1.5, chakraRadius / 12);
+
+    // Outer circle
     ctx.beginPath();
     ctx.arc(chakraX, chakraY, chakraRadius, 0, 2 * Math.PI);
     ctx.stroke();
 
-    ctx.lineWidth = Math.max(1, chakraRadius/20);
+    // 24 spokes
+    ctx.lineWidth = Math.max(1, chakraRadius / 20);
     for (let i = 0; i < 24; i++) {
       const angle = (i / 24) * 2 * Math.PI;
-      const startX = chakraX;
-      const startY = chakraY;
       const endX = chakraX + chakraRadius * Math.cos(angle);
       const endY = chakraY + chakraRadius * Math.sin(angle);
       ctx.beginPath();
-      ctx.moveTo(startX, startY);
+      ctx.moveTo(chakraX, chakraY);
       ctx.lineTo(endX, endY);
       ctx.stroke();
     }
+
+    ctx.restore();
   }
 };


### PR DESCRIPTION
This pull request refactors the Independence Day festive theme to support multiple flags, making it easier to add new country flags and customize their appearance. The implementation is now modular, with each flag defined in its own file and auto-triggered based on date ranges. The Indian flag rendering logic has been moved to a separate file, and the main theme code dynamically selects and draws the appropriate flag. There are also improvements to the visual rendering and configuration options.

**Multi-flag support and modularization:**
* Refactored the Independence Day theme in `package/themes/independence-day/index.js` to support multiple flags by importing flag definitions from separate files and selecting the flag based on user input or date triggers.
* Added a new `package/themes/independence-day/india.js` file containing the Indian flag's properties, trigger dates, color palette, and drawing logic for the Ashoka Chakra.

**Rendering and configuration improvements:**
* Updated the waving flag rendering logic to use a more flexible wave function and palette-based stripe drawing, and delegated custom elements (like the Ashoka Chakra) to each flag's own `drawCustomElement` function.
* Changed default visual settings for better appearance, including blend mode, opacity, and wave amplitude, and simplified handling of device pixel ratio and resizing. [[1]](diffhunk://#diff-cebb806f60144a9f8fad3e5e505fcc476a1b301fa8115778c5bba289c155fa57R1-R73) [[2]](diffhunk://#diff-cebb806f60144a9f8fad3e5e505fcc476a1b301fa8115778c5bba289c155fa57L48-R142)

**Documentation and usage updates:**
* Updated `package/examples/index.html` to clarify how to add new flag buttons for Independence Day, with examples and improved button configuration for selecting different flags.