### PR TITLE
feat(theme) : Updated Indepedence day theme to add animated waving Japan flag variant

### DIFF
--- a/package/examples/index.html
+++ b/package/examples/index.html
@@ -76,7 +76,9 @@
     <div class="buttons">
       <!-- Manual-init example that specifies which flag to use for the independence-day theme.
           You can add more buttons by copying this and changing the flag name. -->
-      <button onclick="Festive.init({forceTheme:'independence-day', themes: {'independence-day': {flag: 'Indian Flag'}}})">Waving Indian Flag</button>
+      <button onclick="Festive.init({forceTheme:'independence-day', themes: {'independence-day': {flag: 'Indian Flag'}}})">Indian Flag</button>
+      <button onclick="Festive.init({forceTheme:'independence-day', themes: {'independence-day': {flag: 'Japan Flag'}}})">Japan Flag</button>
+
       <!-- Example for adding another flag:
           <button onclick="Festive.init({forceTheme:'independence-day', themes: {'independence-day': {flag: 'USA Flag'}}})">Waving USA Flag</button>
       -->

--- a/package/themes/independence-day/index.js
+++ b/package/themes/independence-day/index.js
@@ -7,10 +7,10 @@
  */
 
 import india from './india.js';
-
+import japan from './japan.js';
 // Add other flags here when available:
 // import usa from './usa.js';
-const flags = [india]; // e.g., const flags = [india, usa];
+const flags = [india,japan]; // e.g., const flags = [india, usa];
 
 const allTriggers = flags.flatMap(f => f.triggers || []);
 

--- a/package/themes/independence-day/japan.js
+++ b/package/themes/independence-day/japan.js
@@ -1,0 +1,58 @@
+export default {
+    name: 'Japan Flag',
+    // Auto-trigger for National Foundation Day (Feb 11)
+    triggers: [
+      {
+        type: 'range',
+        monthStart: 2,
+        dayStart: 11,
+        monthEnd: 2,
+        dayEnd: 11
+      }
+    ],
+    palette: [
+      '#FFFFFF', // White background
+      '#BC002D'  // Red circle (Hinomaru)
+    ],
+  
+    drawCustomElement: (ctx, w, h, stripeHeight, getWaveY, t) => {
+      ctx.save();
+  
+      // === Draw waving white background ===
+      ctx.fillStyle = '#FFFFFF';
+      ctx.beginPath();
+      for (let x = 0; x <= w; x += 2) {
+        const y = getWaveY(x, t);
+        if (x === 0) ctx.moveTo(x, y);
+        else ctx.lineTo(x, y);
+      }
+      for (let x = w; x >= 0; x -= 2) {
+        const y = h + getWaveY(x, t);
+        ctx.lineTo(x, y);
+      }
+      ctx.closePath();
+      ctx.fill();
+  
+      // === Draw the red circle (Hinomaru) ===
+      const circleRadius = Math.min(w, h) * 0.18; // official proportions ≈ 3/5 height
+      const circleX = w / 2;
+      const baseY = h / 2;
+  
+      // Draw circle as small vertical wave segments for natural ripple
+      ctx.fillStyle = '#BC002D';
+      const segments = 60; // smoother wave
+      ctx.beginPath();
+      for (let i = 0; i <= segments; i++) {
+        const angle = (i / segments) * 2 * Math.PI;
+        const x = circleX + circleRadius * Math.cos(angle);
+        const y = baseY + circleRadius * Math.sin(angle) + getWaveY(x, t) * 0.5; // subtle ripple
+        if (i === 0) ctx.moveTo(x, y);
+        else ctx.lineTo(x, y);
+      }
+      ctx.closePath();
+      ctx.fill();
+  
+      ctx.restore();
+    }
+  };
+  


### PR DESCRIPTION
This pull request adds support for displaying the Japan national flag as a festive theme for National Foundation Day (February 11). It introduces a new flag implementation, updates the theme configuration, and improves the example UI to allow users to select either the Indian or Japanese flag.

**New Japan Flag Implementation:**

* Added `package/themes/independence-day/japan.js` with a custom drawing function for the Japan flag, including auto-trigger for National Foundation Day and official colors.

**Theme Configuration Updates:**

* Imported the new Japan flag in `package/themes/independence-day/index.js` and included it in the `flags` array so it can be triggered alongside the Indian flag.

**Example UI Improvements:**

* Updated the `<h2>` section in `package/examples/index.html` to add a button for the Japan flag, allowing users to easily switch between Indian and Japanese flags.