### PR TITLE
feat(theme) : Updated Indepedence day theme to add animated waving France flag variant

### DIFF
--- a/package/examples/index.html
+++ b/package/examples/index.html
@@ -76,7 +76,8 @@
     <div class="buttons">
       <!-- Manual-init example that specifies which flag to use for the independence-day theme.
           You can add more buttons by copying this and changing the flag name. -->
-      <button onclick="Festive.init({forceTheme:'independence-day', themes: {'independence-day': {flag: 'Indian Flag'}}})">Waving Indian Flag</button>
+      <button onclick="Festive.init({forceTheme:'independence-day', themes: {'independence-day': {flag: 'Indian Flag'}}})">Indian Flag</button>
+      <button onclick="Festive.init({forceTheme:'independence-day', themes: {'independence-day': {flag: 'France Flag'}}})">France Flag</button>
       <!-- Example for adding another flag:
           <button onclick="Festive.init({forceTheme:'independence-day', themes: {'independence-day': {flag: 'USA Flag'}}})">Waving USA Flag</button>
       -->

--- a/package/themes/independence-day/france.js
+++ b/package/themes/independence-day/france.js
@@ -1,0 +1,55 @@
+export default {
+    name: 'France Flag',
+    // Auto-trigger date range for Bastille Day 🇫🇷
+    triggers: [
+      {
+        type: 'range',
+        monthStart: 7,
+        dayStart: 14,
+        monthEnd: 7,
+        dayEnd: 14
+      }
+    ],
+    palette: [
+      '#0055A4', // Blue
+      '#FFFFFF', // White
+      '#EF4135'  // Red
+    ],
+    drawCustomElement: (ctx, w, h, stripeHeight, getWaveY, t) => {
+      const stripeWidth = w / 3;
+  
+      ctx.save();
+  
+      // Draw each vertical color stripe
+      for (let i = 0; i < 3; i++) {
+        const color = ['#0055A4', '#FFFFFF', '#EF4135'][i];
+        const xStart = i * stripeWidth;
+        const xEnd = (i + 1) * stripeWidth;
+  
+        ctx.beginPath();
+        ctx.moveTo(xStart, 0);
+  
+        // Top waving edge
+        for (let x = xStart; x <= xEnd; x += 3) {
+          const y = getWaveY(x, t);
+          ctx.lineTo(x, y);
+        }
+  
+        // Right edge down
+        ctx.lineTo(xEnd, h);
+  
+        // Bottom waving edge
+        for (let x = xEnd; x >= xStart; x -= 3) {
+          const y = h + getWaveY(x, t);
+          ctx.lineTo(x, y);
+        }
+  
+        ctx.closePath();
+        ctx.fillStyle = color;
+        ctx.fill();
+      }
+  
+      ctx.restore();
+    }
+  };
+  

--- a/package/themes/independence-day/index.js
+++ b/package/themes/independence-day/index.js
@@ -7,10 +7,11 @@
  */
 
 import india from './india.js';
+import france from './france.js';
 
 // Add other flags here when available:
 // import usa from './usa.js';
-const flags = [india]; // e.g., const flags = [india, usa];
+const flags = [india,france]; // e.g., const flags = [india, usa];
 
 const allTriggers = flags.flatMap(f => f.triggers || []);
 


### PR DESCRIPTION
This pull request adds support for the France flag to the Independence Day theme, allowing users to display a waving French flag in the festive examples. The changes include the addition of a new theme file for the France flag, updates to the theme registry, and an updated example in the demo page.

### New France Flag Theme Support

* Added a new theme file `france.js` for the France flag, including its color palette, Bastille Day trigger date, and custom waving flag drawing logic.
* Registered the France flag theme in the `flags` array in `index.js`, enabling it to be used alongside the Indian flag.

### Demo Page Enhancements

* Added a button to the demo page (`index.html`) to allow users to display the France flag, alongside the existing Indian flag button.