### PR TITLE
feat(theme) : Updated Indepedence day theme to add animated waving Bahrain flag variant

### DIFF
--- a/package/examples/index.html
+++ b/package/examples/index.html
@@ -76,7 +76,8 @@
     <div class="buttons">
       <!-- Manual-init example that specifies which flag to use for the independence-day theme.
           You can add more buttons by copying this and changing the flag name. -->
-      <button onclick="Festive.init({forceTheme:'independence-day', themes: {'independence-day': {flag: 'Indian Flag'}}})">Waving Indian Flag</button>
+      <button onclick="Festive.init({forceTheme:'independence-day', themes: {'independence-day': {flag: 'Indian Flag'}}})">Indian Flag</button>
+      <button onclick="Festive.init({forceTheme:'independence-day', themes: {'independence-day': {flag: 'Bahrain Flag'}}})">Bahrain Flag</button>
       <!-- Example for adding another flag:
           <button onclick="Festive.init({forceTheme:'independence-day', themes: {'independence-day': {flag: 'USA Flag'}}})">Waving USA Flag</button>
       -->

--- a/package/themes/independence-day/bahrain.js
+++ b/package/themes/independence-day/bahrain.js
@@ -1,0 +1,63 @@
+export default {
+    name: 'Bahrain Flag',
+    triggers: [
+      {
+        type: 'range',
+        monthStart: 12,
+        dayStart: 16,
+        monthEnd: 12,
+        dayEnd: 16
+      }
+    ],
+    palette: ['#FFFFFF', '#D71A28'],
+  
+    drawCustomElement: (ctx, w, h, stripeHeight, getWaveY, t) => {
+      ctx.save();
+  
+      const whiteWidth = w * 0.25;      // 25% white area
+      const redStartX = whiteWidth;
+      const triangleCount = 5;          // 5 white triangles
+      const triangleBase = h / (triangleCount * 2); // height per half triangle
+      const triangleDepth = w * 0.10;   // depth into red (1/10th width, realistic)
+  
+      // Create waving mask
+      ctx.beginPath();
+      for (let x = 0; x <= w; x += 3) {
+        const y = getWaveY(x, t);
+        if (x === 0) ctx.moveTo(x, y);
+        else ctx.lineTo(x, y);
+      }
+      ctx.lineTo(w, h + getWaveY(w, t));
+      for (let x = w; x >= 0; x -= 3) {
+        const y = h + getWaveY(x, t);
+        ctx.lineTo(x, y);
+      }
+      ctx.closePath();
+      ctx.clip();
+  
+      // Draw red background
+      ctx.fillStyle = '#D71A28';
+      ctx.fillRect(0, 0, w, h);
+  
+      // Draw white section + zigzag
+      ctx.beginPath();
+      ctx.moveTo(0, 0);
+      ctx.lineTo(whiteWidth, 0);
+  
+      // Zigzag border (5 points)
+      for (let i = 0; i < triangleCount * 2; i++) {
+        const y = (i + 1) * triangleBase;
+        const x = i % 2 === 0 ? whiteWidth + triangleDepth : whiteWidth;
+        ctx.lineTo(x, y);
+      }
+  
+      ctx.lineTo(0, h);
+      ctx.closePath();
+  
+      ctx.fillStyle = '#FFFFFF';
+      ctx.fill();
+  
+      ctx.restore();
+    }
+  };
+  

--- a/package/themes/independence-day/index.js
+++ b/package/themes/independence-day/index.js
@@ -7,10 +7,11 @@
  */
 
 import india from './india.js';
+import bahrain from './bahrain.js';
 
 // Add other flags here when available:
 // import usa from './usa.js';
-const flags = [india]; // e.g., const flags = [india, usa];
+const flags = [india,bahrain]; // e.g., const flags = [india, usa];
 
 const allTriggers = flags.flatMap(f => f.triggers || []);
 


### PR DESCRIPTION
This pull request adds support for the Bahrain flag to the Independence Day theme, allowing users to display either the Indian or Bahrain flag on the demo page. The main changes include the addition of the Bahrain flag implementation, updates to the flag selection logic, and improvements to the demo interface.

**New Bahrain flag support:**

* Added a new theme implementation for the Bahrain flag with a custom drawing function, color palette, and trigger date in `package/themes/independence-day/bahrain.js`.
* Registered the Bahrain flag in the list of available flags in `package/themes/independence-day/index.js`, enabling it to be selected and displayed.

**Demo interface improvements:**

* Updated the demo page to include a button for the Bahrain flag, allowing users to easily switch between the Indian and Bahrain flags in `package/examples/index.html`.